### PR TITLE
Adding a base url to config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ description: 2020 November 9th - 13th, Campus La Mola
 owner: Elixir HUB # or company name
 first_published: 2021 # if migrating another site, the year of your first publish
 email: arcila@ebi.ac.uk
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/biohackathon-europe-2021" # the subpath of your site, e.g. /blog
 url: "https://elixir-europe.github.io/biohackathon-europe-2021/" # the base hostname & protocol for your site
 social:
   twitter: https://twitter.com/hashtag/BioHackEU20


### PR DESCRIPTION
This is a temporary fix to make the urls work on the default GitHub pages url (https://elixir-europe.github.io/biohackathon-europe-2021/). We need to change the ownership of the domain name and I think the subdomain will be deleted when we do, so perhaps it's easier to serve it from this url until the proper domain name is applied?