### PR TITLE
Removing call for topics text from home page 

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ layout: landing
 				<li>
 					<ul class="actions my-3">
 						<li>
-							<a href="#landing-processprop" class="button special">Call for project proposals</a>
+							<a href="{{ site.baseurl }}/projects.html" class="button special">Call for project proposals</a>
 						</li>
 					</ul>
 					<p>Bookmark this page and follow us on Twitter to keep up to date:<br /> <a href="https://twitter.com/elixireurope">@ELIXIREurope</a><br /> <a href="https://twitter.com/hashtag/BioHackEU21">#BioHackEU21</a></p>
@@ -155,26 +155,9 @@ layout: landing
 <!-- Three -->
 <section id="landing-processprop" class="wrapper style4 spotlight">
 	<div class="inner">
-		<h2>Hacking Topics</h2>
-<p>Selected hacking topics will be published here once reviewed by the BioHackathon Organising Committee. We are expecting topics to align well with the current interest of life science communities at large. These may include standardised workflows, containerisation, schemas and identifiers, ontology tooling, metadata validation, and training. We encourage submissions of hacking topics from the public and private sector.</p>
-<h3>Call for Project Proposals</h3>
-<p>We ask the project leads to submit a proposal through EasyChair. The proposals will include the following:</p>
-<ul>
-<li>A project description, no longer than 200 words </li>
-<li>Which ELIXIR Platforms/Communities the project aligns to </li>
-<li>Who the leads are, including one person who is nominated as primary lead and main point of contact for communications </li>
-<li>If all project leads cannot attend in person, the person they nominate to help facilitate a hybrid project at the venue </li>
-<li>Expected outcomes </li>
-<li>Number of people/Nodes that will be expected to participate</li>
-<li>Any people (two maximum) from Europe you would like to invite who are critical to the success of the project (name /institute/email)</li>
-<li>Expected outcome and timeframe </li>
-<li>The repository where the code will reside</li>
-<li>How your project would advance if not selected</li>
-<li>How you will advance after the BioHackathon</li>
-<li>If you are planning to attend in person, and if your project could be run virtually</li>
-</ul>
-<p>We expect the projects to be submitted to <a href="{{ site.baseurl }}/biohackrxiv.html">BioHackrXiv</a> within six months after end of the BioHackathon, wherever possible. <strong>The deadline for proposals is 1 April 2021.</strong></p>
-<a class="button special" href="{{ site.baseurl }}/ipdiscl.html">IP Disclaimer</a>
+		<h2>Hacking projects</h2>
+<p>Selected hacking projects will be published on this site once reviewed by the BioHackathon Organising Committee. We are expecting topics to align well with the current interest of life science communities at large. These may include standardised workflows, containerisation, schemas and identifiers, ontology tooling, metadata validation, and training. We encourage submissions of hacking topics from the public and private sector.</p>
+<a href="{{ site.baseurl }}/projects.html" class="button special">Call for project proposals</a>
 	</div>
 	</section>
 	<!-- Three -->

--- a/projects.html
+++ b/projects.html
@@ -21,7 +21,7 @@ section id="hacking-projects">
    -->
 <section>
     <h2>Call for Project Proposals</h2>
-    <p>We ask the project leads to submit a proposal through EasyChair. The proposals will include the following:</p>
+    <p>We ask the project leads to submit a proposal through <a href="https://easychair.org/conferences/?conf=bh2021">EasyChair</a>. The proposals will include the following:</p>
     <ul>
     <li>A project description, no longer than 200 words </li>
     <li>Which ELIXIR Platforms/Communities the project aligns to </li>

--- a/registration.html
+++ b/registration.html
@@ -13,7 +13,7 @@ title: Registration
 
 <p>We believe the new format will allow everyone to participate in the BioHackathon and deliver tangible outcomes from the selected projects.</p>
 
-<p>BioHackathon Europe has limited space for face-to-face participation. The registration is based on a first-come, first-served basis. Don’t miss your chance to attend this year and register before 17 September 2021.</p>
+<p>BioHackathon Europe has limited space for face-to-face participation. The registration is based on a first-come, first-served basis. </p>
 
 
         <h3>Code of Conduct</h3>


### PR DESCRIPTION
The text is now in the Projects page.